### PR TITLE
CI: Use `pueblo.ngr` for running the Meltano test job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,4 @@ jobs:
 
     - name: Verify "to-database"
       run: |
-        cd to-database
-        meltano install
-        meltano run test
+        ngr test to-database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@
 # docker compose -f docker-compose.yml up
 version: "2.1"
 services:
-  postgres:
+  postgresql:
     image: ankane/pgvector:latest
     command: postgres -c log_statement=all
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 meltano==3.2.0
+pueblo @ git+https://github.com/pyveci/pueblo.git@meltano

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 meltano==3.2.0
-pueblo @ git+https://github.com/pyveci/pueblo.git@meltano
+pueblo @ git+https://github.com/pyveci/pueblo.git@main

--- a/to-database/README.md
+++ b/to-database/README.md
@@ -8,7 +8,7 @@ within `meltano.yml`.
 
 Run a PostgreSQL server with pgvector extension.
 ```shell
-docker compose -f ../docker-compose.yml up
+docker compose -f ../docker-compose.yml up postgresql
 ```
 
 In another shell, before running any `psql` command, define the authentication

--- a/to-database/meltano.yml
+++ b/to-database/meltano.yml
@@ -15,7 +15,7 @@ plugins:
 
   - name: tap-smoke-test
     namespace: tap_smoke_test
-    pip_url: git+https://github.com/meltano/tap-smoke-test.git
+    pip_url: git+https://github.com/meltano/tap-smoke-test.git@python3.12
     executable: tap-smoke-test
     config:
       streams:


### PR DESCRIPTION
## About

There is now a shortcut for invoking the `test` job of a Meltano project.

## Example

```shell
ngr test to-database
```


## References

- https://github.com/pyveci/pueblo/pull/47